### PR TITLE
override the default host configurations

### DIFF
--- a/lib/carrierwave/storage/azure.rb
+++ b/lib/carrierwave/storage/azure.rb
@@ -18,6 +18,12 @@ module CarrierWave
           uploader.azure_credentials.map do |key, val|
             ::Azure.config.send("#{key}=", val)
           end unless uploader.azure_credentials.nil?
+
+	  unless uploader.azure_host.nil?
+            ::Azure.config.storage_blob_host = uploader.azure_host
+            ::Azure.config.storage_table_host= uploader.azure_host
+            ::Azure.config.storage_queue_host= uploader.azure_host
+          end 
           ::Azure::BlobService.new
         end
       end


### PR DESCRIPTION
in many situation we may need to override the host configuration.
e.g. In windows azure China, we use the host like http://*.blob.core.chinacloudapi.cn rather than the default one.
So I change this setting
