### PR TITLE
Send files in chunks

### DIFF
--- a/lib/carrierwave/storage/azure.rb
+++ b/lib/carrierwave/storage/azure.rb
@@ -36,9 +36,6 @@ module CarrierWave
           file_to_send  = ::File.open(file.file, 'rb')
           blocks        = []
 
-          file_size = file_to_send.size.to_f / 2**20
-          puts '%.2f' % file_size
-
           until file_to_send.eof?
             block_id = Base64.urlsafe_encode64(SecureRandom.uuid)
 

--- a/lib/carrierwave/storage/azure.rb
+++ b/lib/carrierwave/storage/azure.rb
@@ -40,7 +40,7 @@ module CarrierWave
           until file_to_send.eof?
             i += 1
             @content = file_to_send.read 4194304 # Send 4MB chunk
-            @connection.create_blob_block @uploader.azure_container, @path, i.to_s, content
+            @connection.create_blob_block @uploader.azure_container, @path, i.to_s, @content
             blocks << i.to_s
           end
 


### PR DESCRIPTION
Azure storage has a limit of ~65mb per file/chunk so it should be uploaded in 4mb chunks.
