### PR TITLE
fix typo on #exist? method name

### DIFF
--- a/lib/carrierwave/storage/azure.rb
+++ b/lib/carrierwave/storage/azure.rb
@@ -60,7 +60,7 @@ module CarrierWave
           @content_type = new_content_type
         end
 
-        def exitst?
+        def exist?
           blob.nil?
         end
 


### PR DESCRIPTION
renamed the method to CarrierWave::Storage::Azure::File#exist? following the naming criteria on the 
File class (#exists? exists, but's deprecated)

Fixes #5 
