### PR TITLE
fix error Azure::BlobService

### DIFF
--- a/lib/carrierwave/storage/azure.rb
+++ b/lib/carrierwave/storage/azure.rb
@@ -18,7 +18,7 @@ module CarrierWave
           %i(storage_account_name storage_access_key storage_blob_host).each do |key|
             ::Azure.config.send("#{key}=", uploader.send("azure_#{key}"))
           end
-          ::Azure::BlobService.new
+          ::Azure::Blob::BlobService.new
         end
       end
 


### PR DESCRIPTION
There's an error like this when I tried to save the file.
`NameError (uninitialized constant Azure::BlobService):`

I have fixed it by modifying it into `Azure::Blob::BlobService`
