### PR TITLE
Use Azure::Blob::BlobService instead of Azure::BlobService in order t…

### DIFF
--- a/lib/carrierwave/storage/azure.rb
+++ b/lib/carrierwave/storage/azure.rb
@@ -18,7 +18,7 @@ module CarrierWave
           %i(storage_account_name storage_access_key storage_blob_host).each do |key|
             ::Azure.config.send("#{key}=", uploader.send("azure_#{key}"))
           end
-          ::Azure::BlobService.new
+          ::Azure::Blob::BlobService.new
         end
       end
 


### PR DESCRIPTION
…o make it work with azure 0.7.0

Azure 0.7.0 was released on August 17, 2015. That release made some backward incompatible changes.

This pull request makes `carrierwave-azure` work with latest `azure`.
