### PR TITLE
rename method `exitsts?` to `exists?`

### DIFF
--- a/lib/carrierwave/storage/azure.rb
+++ b/lib/carrierwave/storage/azure.rb
@@ -60,7 +60,7 @@ module CarrierWave
           @content_type = new_content_type
         end
 
-        def exitst?
+        def exists?
           blob.nil?
         end
 


### PR DESCRIPTION
likely a typo. 
