### PR TITLE
fix call to Azure::Blob::BlobService

### DIFF
--- a/lib/carrierwave/storage/azure.rb
+++ b/lib/carrierwave/storage/azure.rb
@@ -18,7 +18,7 @@ module CarrierWave
           %i(storage_account_name storage_access_key storage_blob_host).each do |key|
             ::Azure.config.send("#{key}=", uploader.send("azure_#{key}"))
           end
-          ::Azure::BlobService.new
+          ::Azure::Blob::BlobService.new
         end
       end
 


### PR DESCRIPTION
azure gem version 0.7.9 uses Azure::Blob::BlobService instead of Azure::BlobService.